### PR TITLE
Fix typo in "main" key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "safari-beauty-toolbar",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Make the Safari Toolbar more consistent with your brand colors",
   "repository": "git+https://github.com/neSpecc/safari-beauty-toolbar.git",
   "bugs": {
     "url": "https://github.com/neSpecc/safari-beauty-toolbar/issues"
   },
   "homepage": "https://ifmo.su/beauty-toolbar",
-  "main": "buils/sct.min.js",
+  "main": "build/sct.min.js",
   "scripts": {
     "minimize": "uglifyjs ./build/sct.js --output ./build/sct.min.js --comments",
     "css": "postcss ./demo/demo.pcss --no-map  -u postcss-cssnext postcss-nested -o ./demo/demo.css --watch"


### PR DESCRIPTION
Right now it points to `buil`**`s`**`/sct.min.js`, which leads to unresolved module error