### PR TITLE
Add export to the module

### DIFF
--- a/src/sct.ts
+++ b/src/sct.ts
@@ -52,7 +52,7 @@ interface IAnimationParams {
   speed?: number;
 }
 
-class SBToolbar {
+export default class SBToolbar {
 
   /**
    * Current revision number


### PR DESCRIPTION
Right now you can't use it via `import SBToolbar from 'safari-beauty-toolbar'` because nothing is exported. This PR adds a default export